### PR TITLE
#1 add support to dotnet test

### DIFF
--- a/Expecto.Template.nuspec
+++ b/Expecto.Template.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Expecto.Template</id>
-    <version>6.0.0</version>
+    <version>7.0.0-RC</version>
     <authors>Michał Niegrzybowski</authors>
     <owners>Michał Niegrzybowski</owners>
     <licenseUrl>https://github.com/MNie/Expecto.Template/blob/master/LICENSE</licenseUrl>
@@ -16,6 +16,8 @@
     </packageTypes>
 	<dependencies>
 		<dependency id="Expecto" version="[5.0.0, 6.0.0)"/>
+    <dependency id="YoloDev.Expecto.TestSdk" version="[0.1.0, 1.0.0)"/>
+    <dependency id="Microsoft.NET.Test.Sdk" version="[15.0.0, 16.0.0)"/>
 	</dependencies>
   </metadata>
 </package>

--- a/ExpectoTemplate.fsproj
+++ b/ExpectoTemplate.fsproj
@@ -12,6 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Expecto" Version="5.*" />
+    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add support to dotnet test, via (test sdk)[https://www.nuget.org/packages/YoloDev.Expecto.TestSdk/]

Ref: #1 
CC: @Alxandr