### PR TITLE
Updated to dotnet 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: bionic
 language: csharp
 mono: none
-dotnet: 5.0
+dotnet: 6.0
 sudo: required
 
 script:

--- a/Expecto.Template.nuspec
+++ b/Expecto.Template.nuspec
@@ -2,14 +2,14 @@
 <package >
   <metadata>
     <id>Expecto.Template</id>
-    <version>14.0.0</version>
+    <version>15.0.0</version>
     <authors>Michał Niegrzybowski</authors>
     <owners>Michał Niegrzybowski</owners>
     <licenseUrl>https://github.com/MNie/Expecto.Template/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/MNie/Expecto.Template</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Expecto .net Template</description>
-    <copyright>Copyright 2019</copyright>
+    <copyright>Copyright 2019-2022</copyright>
     <tags>.net Expecto template</tags>
     <packageTypes>
       <packageType name="Template"/>

--- a/ExpectoTemplate.fsproj
+++ b/ExpectoTemplate.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Expecto" Version="9.*" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
-    <PackageReference Update="FSharp.Core" Version="5.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Update="FSharp.Core" Version="6.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
.NET 5 is [out of support](https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/) so new projects should be created with the newer version of the SDK.

This template was tested by creating and running a new project on both ARM and Intel versions of the dotnet 6.0 SDK.