### PR TITLE
nuget => NuGet; .net => .NET

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -1,7 +1,7 @@
 {
     "author": "Michał Niegrzybowski",
     "classifications": [ "Test" ],
-    "name": "Expecto .net core Template",
+    "name": "Expecto .NET core Template",
     "identity": "Expecto.Template",        
     "shortName": "expecto",              
     "tags": {

--- a/Expecto.Template.nuspec
+++ b/Expecto.Template.nuspec
@@ -8,9 +8,9 @@
     <licenseUrl>https://github.com/MNie/Expecto.Template/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/MNie/Expecto.Template</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Expecto .net Template</description>
+    <description>Expecto .NET Template</description>
     <copyright>Copyright 2019-2022</copyright>
-    <tags>.net Expecto template</tags>
+    <tags>.NET Expecto template</tags>
     <packageTypes>
       <packageType name="Template"/>
     </packageTypes>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 [![NuGet Pre Release](https://buildstats.info/nuget/Expecto.Template?includePreReleases=true)](https://www.nuget.org/packages/Expecto.Template)
 [![Build Status](https://travis-ci.org/MNie/Expecto.Template.svg?branch=master)](https://travis-ci.org/MNie/Expecto.Template)
 
-# Expecto .net Template
+# Expecto .NET Template
 It's a template for [Expecto](https://github.com/haf/expecto) F# test library.
 
 # How to use it?
-* install template as a .net template from nuget
-* install template as a .net template locally
+* install template as a .NET template from nuget
+* install template as a .NET template locally
 
-# How to install it as a template from nuget?
+# How to install it as a template from NuGet?
 * run `dotnet new -i Expecto.Template`
-* create new project executing `dotnet new expecto -n PROJECT_NAME -o FOLDER_NAME -lang F#`
+* create a new project executing `dotnet new expecto -n PROJECT_NAME -o FOLDER_NAME -lang F#`
 
 # How to install it as a template locally?
 * download repository


### PR DESCRIPTION
Not a very vital change, but I noticed some little typos in ".net" and "nuget" (they should be ".NET" and "NuGet").
I also added a missing "a".

I wonder if changing the description implies changing the NuGet package version though.

(Thank you for the template!!!)