### PR TITLE
Updates for Expecto 10

### DIFF
--- a/ExpectoTemplate.fsproj
+++ b/ExpectoTemplate.fsproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Expecto" Version="9.*" />
+    <PackageReference Include="Expecto" Version="10.*" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Update="FSharp.Core" Version="6.*" />
+    <PackageReference Update="FSharp.Core" Version="7.*" />
   </ItemGroup>
 </Project>

--- a/Main.fs
+++ b/Main.fs
@@ -3,4 +3,4 @@ open Expecto
 
 [<EntryPoint>]
 let main argv =
-    Tests.runTestsInAssembly defaultConfig argv
+    Tests.runTestsInAssemblyWithCLIArgs [] argv


### PR DESCRIPTION
refs #19 

Expecto 10 made some changes to the public API, and also requires FSharp.Core >= 7.0.200, so update for both of those.

I don't have much experience with creating templates, so I hope this is all that's needed.